### PR TITLE
TriangleNet_Engine: `IRendermesh()` first checks if any RenderMesh is in CustomData; add null checks

### DIFF
--- a/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
+++ b/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
@@ -71,8 +71,9 @@ namespace BH.Engine.Representation
 
             // - This is where our BH.Engine.RecordError loses against Exceptions.
             // - Using Exception throwing, I could make sure that: if this method is used "alone" as in a script component, I throw an error;
-            // - if this method is called within another method, I catch the Exception and decide whether to return it based on the context.
+            // - if this method is called within another method, I catch the Exception and decide whether to expose it based on the context.
             // - e.g. I'd like this in Speckle_Toolkit, SpeckleRepresentation.cs, line 104.
+
             //if (geometricalRepresentation == null & !(obj is CustomObject)) // do not throw error for CustomObjects.
             //    BH.Engine.Reflection.Compute.RecordError($"Could not compute the Geometrical Representation for the object of type {obj.GetType().Name}");
 

--- a/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
+++ b/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
@@ -43,6 +43,8 @@ namespace BH.Engine.Representation
             "The Geometrical Representation is an IGeometry that can be used to represent the object in another environment.")] //e.g. to 3D-print a point, you want to print a Sphere.
         public static IGeometry IGeometricalRepresentation(this IObject obj, RepresentationOptions reprOptions = null)
         {
+            if (obj == null) return null;
+
             reprOptions = reprOptions ?? new RepresentationOptions();
 
             IGeometry geometricalRepresentation = null;

--- a/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
+++ b/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
@@ -49,12 +49,24 @@ namespace BH.Engine.Representation
 
             IGeometry geometricalRepresentation = null;
 
-            // - First check if there is a specific GeometricalRepresentation method for the IObject.
+            // - Dynamic dispatch
             geometricalRepresentation = GeometricalRepresentation(obj as dynamic, reprOptions);
             if (geometricalRepresentation != null)
                 return geometricalRepresentation;
 
-            // - If not, check if the object is a IGeometry, and if it is return itself.
+            // Throw error if not found (but only if the object is not a CustomObject)
+            if (geometricalRepresentation == null & !(obj is CustomObject)) // do not throw error for CustomObjects.
+                throw new Exception($"Could not compute the Geometrical Representation for the object of type {obj.GetType().Name}.");
+
+            return geometricalRepresentation;
+        }
+
+        // Fallback
+        private static IGeometry GeometricalRepresentation(this IObject obj, RepresentationOptions reprOptions = null)
+        {
+            IGeometry geometricalRepresentation = null;
+
+            // - Check if the object is a IGeometry, and if it is return itself.
             geometricalRepresentation = obj as IGeometry;
             if (geometricalRepresentation != null)
                 return geometricalRepresentation;
@@ -69,16 +81,7 @@ namespace BH.Engine.Representation
                 if (geometricalRepresentation is CompositeGeometry && (geometricalRepresentation as CompositeGeometry).Elements.Count < 1)
                     geometricalRepresentation = null;
 
-            if (geometricalRepresentation == null & !(obj is CustomObject)) // do not throw error for CustomObjects.
-                throw new Exception($"Could not compute the Geometrical Representation for the object of type {obj.GetType().Name}.");
-
             return geometricalRepresentation;
-        }
-
-        // Fallback
-        private static IGeometry GeometricalRepresentation(this IObject obj, RepresentationOptions reprOptions = null)
-        {
-            throw new MissingMethodException($"Could not find a method to compute the Geometrical Representation for the object of type {obj.GetType().Name}.");
         }
     }
 }

--- a/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
+++ b/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/IGeometricalRepresentation.cs
@@ -69,13 +69,8 @@ namespace BH.Engine.Representation
                 if (geometricalRepresentation is CompositeGeometry && (geometricalRepresentation as CompositeGeometry).Elements.Count < 1)
                     geometricalRepresentation = null;
 
-            // - This is where our BH.Engine.RecordError loses against Exceptions.
-            // - Using Exception throwing, I could make sure that: if this method is used "alone" as in a script component, I throw an error;
-            // - if this method is called within another method, I catch the Exception and decide whether to expose it based on the context.
-            // - e.g. I'd like this in Speckle_Toolkit, SpeckleRepresentation.cs, line 104.
-
-            //if (geometricalRepresentation == null & !(obj is CustomObject)) // do not throw error for CustomObjects.
-            //    BH.Engine.Reflection.Compute.RecordError($"Could not compute the Geometrical Representation for the object of type {obj.GetType().Name}");
+            if (geometricalRepresentation == null & !(obj is CustomObject)) // do not throw error for CustomObjects.
+                throw new Exception($"Could not compute the Geometrical Representation for the object of type {obj.GetType().Name}.");
 
             return geometricalRepresentation;
         }
@@ -83,7 +78,7 @@ namespace BH.Engine.Representation
         // Fallback
         private static IGeometry GeometricalRepresentation(this IObject obj, RepresentationOptions reprOptions = null)
         {
-            return null;
+            throw new MissingMethodException($"Could not find a method to compute the Geometrical Representation for the object of type {obj.GetType().Name}.");
         }
     }
 }

--- a/TriangleNet_Engine/Compute/Representation/RenderMesh/IRenderMesh.cs
+++ b/TriangleNet_Engine/Compute/Representation/RenderMesh/IRenderMesh.cs
@@ -61,18 +61,11 @@ namespace BH.Engine.Representation
             // E.g. A BH.oM.Geometry.Point can only be represented with a Sphere, a Pixel, a Voxel, etc.
             IGeometry geomRepr = IGeometricalRepresentation(obj, renderMeshOptions.RepresentationOptions);
 
-            if (geomRepr == null) // Could not compute the geometrical representation for that object.
-            {
-                // I need to throw the Error here instead than in IGeometricalRepresentation because we don't have Error catch.
-                // See comment in IGeometricalRepresentation().
-                BH.Engine.Reflection.Compute.RecordError($"Could not compute the GeometricalRepresentation for {obj.GetType().Name}");
-                return null; 
-            }
-
-            renderMesh = RenderMesh(geomRepr as dynamic, renderMeshOptions);
+            if (geomRepr != null)
+                renderMesh = RenderMesh(geomRepr as dynamic, renderMeshOptions);
 
             if (renderMesh == null)
-                BH.Engine.Reflection.Compute.RecordError($"Could not find a method to compute the {nameof(BH.oM.Graphics.RenderMesh)} of {obj.GetType().Name}");
+                throw new Exception($"Could not compute the {nameof(BH.oM.Graphics.RenderMesh)} of {obj.GetType().Name}.");
 
             return renderMesh;
         }
@@ -80,7 +73,7 @@ namespace BH.Engine.Representation
         // Fallback
         private static BH.oM.Graphics.RenderMesh RenderMesh(this IGeometry geom, RenderMeshOptions renderMeshOptions = null)
         {
-            return null;
+            throw new MissingMethodException($"Could not find a method to compute the {nameof(BH.oM.Graphics.RenderMesh)} of {geom.GetType().Name}.");
         }
 
     }

--- a/TriangleNet_Engine/Compute/Representation/RenderMesh/IRenderMesh.cs
+++ b/TriangleNet_Engine/Compute/Representation/RenderMesh/IRenderMesh.cs
@@ -29,7 +29,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using BH.Engine.Geometry;
 using BH.oM.Base;
-
+using BH.Engine.Graphics;
+using System.ComponentModel;
 
 namespace BH.Engine.Representation
 {
@@ -42,6 +43,8 @@ namespace BH.Engine.Representation
         // Main interface method
         public static BH.oM.Graphics.RenderMesh IRenderMesh(this IObject obj, RenderMeshOptions renderMeshOptions = null)
         {
+            if (obj == null) return null;
+
             renderMeshOptions = renderMeshOptions ?? new RenderMeshOptions();
 
             if (obj is BH.oM.Graphics.RenderMesh)

--- a/TriangleNet_Engine/Compute/Representation/RenderMesh/IRenderMesh.cs
+++ b/TriangleNet_Engine/Compute/Representation/RenderMesh/IRenderMesh.cs
@@ -31,12 +31,17 @@ using BH.Engine.Geometry;
 using BH.oM.Base;
 using BH.Engine.Graphics;
 using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Representation
 {
     public static partial class Compute
     {
         // Main interface method
+        [Description("Computes the Geometrical Representation of the input object and then attempts to mesh it.")]
+        [Input("obj","Any object defined within BHoM.")]
+        [Input("renderMeshOptions", "Options that regulate both the calculation of the Geometrical Representation and how it should be meshed.")]
+        [Output("A RenderMesh, which is a geometrical mesh that can potentially have additional attributes like Colours.")]
         public static BH.oM.Graphics.RenderMesh IRenderMesh(this IObject obj, RenderMeshOptions renderMeshOptions = null)
         {
             if (obj == null) return null;

--- a/TriangleNet_Engine/Modify/Representation/RenderMesh/SetRendermesh.cs
+++ b/TriangleNet_Engine/Modify/Representation/RenderMesh/SetRendermesh.cs
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Graphics;
+using BH.Engine.Graphics;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+
+namespace BH.Engine.Representation
+{
+    public static partial class Modify
+    {
+        [Description("Sets a RenderMesh in the CustomData of the BHoMObject at the specified customDataKey (default: `RenderMesh`).\n" +
+            "The RenderMesh should contain a valid representation for the BHoMObject.")]
+        public static IBHoMObject SetRendermesh(this IBHoMObject bHoMObject, IGeometry representation, string customDataKey = "RenderMesh")
+        {
+            if (bHoMObject == null || representation == null || string.IsNullOrWhiteSpace(customDataKey))
+                return null;
+
+            RenderMesh rM = representation as RenderMesh;
+            Mesh m = representation as Mesh;
+
+            if (rM == null && m != null)
+                rM = m.ToRenderMesh();
+
+            if (rM == null)
+            {
+                // Try computing a RenderMesh from the specified representation Geometry
+                BH.Engine.Reflection.Compute.RecordNote($"The input {nameof(representation)} is neither a {nameof(BH.oM.Graphics.RenderMesh)} or a {nameof(BH.oM.Geometry.Mesh)}. Attempting to compute a RenderMesh for it.");
+
+                rM = Compute.IRenderMesh(representation);
+            }
+
+            IBHoMObject clonedObj = bHoMObject.GetShallowClone();
+
+            clonedObj.CustomData[customDataKey] = rM;
+
+            return clonedObj;
+        }
+    }
+}
+

--- a/TriangleNet_Engine/Query/Representation/RenderMesh/TryGetRendermesh.cs
+++ b/TriangleNet_Engine/Query/Representation/RenderMesh/TryGetRendermesh.cs
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Graphics;
+using BH.Engine.Graphics;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+
+namespace BH.Engine.Representation
+{
+    public static partial class Query
+    {
+        [Description("Retrieves a representation from the specified IBHoMObject CustomData key, if present. Returns it as a RenderMesh.\n" +
+             "If the representation is stored as a BH.oM.Geometry.Mesh type, it's converted to a RenderMesh.\n" +
+             "If the CustomData contains a list of RenderMeshes or Meshes, they are joined together into a single RenderMesh.")]
+        public static bool TryGetRendermesh(this IBHoMObject bHoMObject, out RenderMesh renderMesh, string customDataKey = "RenderMesh")
+        {
+            if (string.IsNullOrWhiteSpace(customDataKey))
+            {
+                renderMesh = null;
+                return false;
+            }
+
+            renderMesh = null;
+
+            if (bHoMObject != null)
+            {
+                object renderMeshObj = null;
+                bHoMObject.CustomData.TryGetValue(customDataKey, out renderMeshObj);
+
+                if (renderMeshObj != null)
+                {
+                    renderMesh = renderMeshObj as RenderMesh;
+                    Mesh geomMesh = renderMeshObj as Mesh;
+
+                    if (renderMesh != null)
+                        return true;
+
+                    if (geomMesh != null)
+                    {
+                        renderMesh = geomMesh.ToRenderMesh();
+                        return true;
+                    }
+
+                    if (typeof(IEnumerable<object>).IsAssignableFrom(renderMeshObj.GetType()))
+                    {
+                        List<object> objects = renderMeshObj as List<object>;
+
+                        List<RenderMesh> renderMeshes = objects.OfType<RenderMesh>().ToList();
+                        List<Mesh> geomMeshes = objects.OfType<Mesh>().ToList();
+
+                        if (geomMeshes.Count > 0)
+                        {
+                            geomMesh = Compute.JoinMeshes(geomMeshes);
+                            renderMeshes.Add(geomMesh.ToRenderMesh());
+                        }
+
+                        if (renderMeshes.Count > 0)
+                            renderMesh = Compute.JoinRenderMeshes(renderMeshes);
+                    }
+
+                    if (renderMesh != null)
+                        return true;
+                    else
+                        return false;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+

--- a/TriangleNet_Engine/TriangleNet_Engine.csproj
+++ b/TriangleNet_Engine/TriangleNet_Engine.csproj
@@ -100,6 +100,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Query\Representation\RenderMesh\TryGetRendermesh.cs" />
+    <Compile Include="Modify\Representation\RenderMesh\SetRendermesh.cs" />
     <Compile Include="Compute\DelaunayTriangulation.cs" />
     <Compile Include="Compute\Representation\GeometricalRepresentation\Element0D\Point.cs" />
     <Compile Include="Compute\Representation\GeometricalRepresentation\Element0D\Structure\Node.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Close #38 
Closes #39

<!-- Add short description of what has been fixed -->

A few quality of life improvements for the RenderMesh/Representation workflows:
- `IRendermesh()` first checks if any RenderMesh is in CustomData; if found, avoid attempting to compute a GeometricalRepresentation/RenderMesh. This avoids having to done this check in every Toolkit that uses `IRendermesh()`.
- Added null checks in `IRendermesh()` and `IGeometricalRepresentation()` on the input object. This avoids error in UI for null objects.
- Added `Modify.SetRenderMesh()`. This attaches an input `RenderMesh` to a BHoMObject's CustomData. If the input is not a `RenderMesh`, it tries computing the RenderMesh for it.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EhlSw8CPOXJEmMZnBdLhYRoBj_nKgzazrvE4iBa0s8Unmw?e=Ry1nDh

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- `IRendermesh()` first checks if any RenderMesh is in CustomData; if found, avoid attempting to compute a GeometricalRepresentation/RenderMesh. This avoids having to done this check in every Toolkit that uses `IRendermesh()`.
- Added null checks in `IRendermesh()` and `IGeometricalRepresentation()` on the input object. This avoids error in UI for null objects.
- Added `Modify.SetRenderMesh()`. This attaches an input `RenderMesh` to a BHoMObject's CustomData. If the input is not a `RenderMesh`, it tries computing the RenderMesh for it.
