### PR TITLE
Adding CullDuplicates() on the input

### DIFF
--- a/TriangleNet_Engine/Compute/VoronoiRegions.cs
+++ b/TriangleNet_Engine/Compute/VoronoiRegions.cs
@@ -47,6 +47,7 @@ namespace BH.Engine.Geometry.Triangulation
         [Output("regions", "Voronoi regions calculated by the method. The position in the list will correspond to the position in the list of the provided points.")]
         public static List<Polyline> VoronoiRegions(List<Point> points, Plane plane = null, double boundarySize = -1, double tolerance = Tolerance.Distance)
         {
+            points = points.CullDuplicates(tolerance);
 
             //Preform check all inputs that triangulation can be done
             if (points == null || points.Count < 2)
@@ -196,6 +197,7 @@ namespace BH.Engine.Geometry.Triangulation
         [Output("regions", "Voronoi regions calculated by the method. The position in the list will correspond to the position in the list of the provided points.")]
         public static List<List<PolyCurve>> VoronoiRegions(List<Point> points, ICurve boundaryCurve, List<ICurve> openingCurves = null, Plane plane = null, double boundarySize = -1, double tolerance = Tolerance.Distance)
         {
+            points = points.CullDuplicates(tolerance);
             openingCurves = openingCurves ?? new List<ICurve>();
 
             List<Point> checkingPoints = new List<Point>(points);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #46 

<!-- Add short description of what has been fixed -->
To avoid differing results adding `CullDuplicates()` on the input Points list.

### Test files
<!-- Link to test files to validate the proposed changes -->
[SharePoint](https://burohappold.sharepoint.com/:f:/s/BHoM/EqzUo5M3lSZJvcdLZ3KTHssBvEfmJirQEeFjCwyvH9gYkA?e=vWQC7D).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updated `VoronoiRegions()` to cull duplicated `Point`s from the input list in the `TriangleNet_Engine`. 

### Additional comments
<!-- As required -->
Before:
![image](https://user-images.githubusercontent.com/48125514/93450578-6df9d200-f8d6-11ea-8fa5-d220e8f15087.png)
After:
![image](https://user-images.githubusercontent.com/48125514/93450635-7b16c100-f8d6-11ea-8a86-03da790360a8.png)
