### PR TITLE
Set .NET framework version to 4.5.2

### DIFF
--- a/TriangleNet_Engine/TriangleNet_Engine.csproj
+++ b/TriangleNet_Engine/TriangleNet_Engine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TriangleNet_Engine</RootNamespace>
     <AssemblyName>TriangleNet_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
   
### Issues addressed by this PR
Set the .NET framework version of the projects in this toolkit to 4.5.2

### Test files
This PR will be reviewed by making sure that an installer can be produced from it. 
