### PR TITLE
Update Panel representation to use Total thickness rather than AverageThickness

### DIFF
--- a/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/Element2D/Structure/Panel.cs
+++ b/TriangleNet_Engine/Compute/Representation/GeometricalRepresentation/Element2D/Structure/Panel.cs
@@ -60,7 +60,7 @@ namespace BH.Engine.Representation
             {
                 CompositeGeometry compositeGeometry = new CompositeGeometry();
 
-                double thickness = panel.Property.IAverageThickness();
+                double thickness = panel.Property.ITotalThickness();
                 Vector translateVect = new Vector() { Z = -thickness / 2 };
                 Vector extrudeVect = new Vector() { Z = thickness };
 


### PR DESCRIPTION

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/2819
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Add short description of what has been fixed -->

Average thickness is repurposed in the Structure_Engine. Instead relying on the ITotalThickness method for extrusion generation.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->