### PR TITLE
Added ability for IRationalise to return Polygon and other IPolylines as Polyline for downstream operations

### DIFF
--- a/TriangleNet_Engine/Compute/Representation/RenderMesh/Rationalise/IRationalise.cs
+++ b/TriangleNet_Engine/Compute/Representation/RenderMesh/Rationalise/IRationalise.cs
@@ -40,8 +40,8 @@ namespace BH.Engine.Representation
         [Description("Rationalises the Curve into a Polyline.")]
         public static Polyline IRationalise(this ICurve curve, RenderMeshOptions renderMeshOptions = null)
         {
-            if (curve is Polyline) // no need to rationalise
-                return curve as Polyline;
+            if (curve is IPolyline) // no need to rationalise
+                return curve.IToPolyline();
 
             if (curve is Line) // no need to rationalise
                 return new Polyline() { ControlPoints = (curve as Line).ControlPoints() };


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #136 

Fixes bug where IPolylines that were not Polylines were skipped and returned an error.


### Test files
[Test Script](https://github.com/BuroHappoldEngineering/ModelLaundry_Toolkit/issues/378)


